### PR TITLE
Fix typo in BankAccount Interface

### DIFF
--- a/src/it/unibo/oop/lab/exception2/BankAccount.java
+++ b/src/it/unibo/oop/lab/exception2/BankAccount.java
@@ -37,7 +37,7 @@ public interface BankAccount {
      * @param usrID
      *            id of the user requesting this opera
      * @param amount
-     *            amount to be withdrawn via AT
+     *            amount to be withdrawn via ATM
      */
     void withdrawFromATM(int usrID, double amount);
 


### PR DESCRIPTION
There's a `M` missing from the description of the method `withdrawFromATM` in `it.unibo.oop.lab.exception2.BankAccount`